### PR TITLE
Closes #14 - [Bug] MSCK REPAIR TABLE job not finding new partitions

### DIFF
--- a/src/msck_repair/src/msck_repair.py
+++ b/src/msck_repair/src/msck_repair.py
@@ -23,5 +23,6 @@ input_df = wr.catalog.tables(database=database_name)
 
 for index, row in input_df.iterrows():
     print(f"Repairing table: {database_name}.{row["Table"]}")
-    wr.athena.repair_table(table=row["Table"])
+    status = wr.athena.repair_table(database=database_name, table=row["Table"])
+    print(f"Status: {status}")
 print(f"Ending job: {datetime.now(timezone.utc)}")


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
Closes #14 - [Bug] MSCK REPAIR TABLE job not finding new partitions.

Need to send the database to the repair_table call, as the analytics tables are not in the default schema.



## Testing Performed
Verified by running job locally from Docker, will monitor the job executing cloud side over the next few days.

## Code Changes
See above.

Modified ./src/msck_repair.py


## Checklist
Confirm that the following have been completed:

* [ ] All new jobs have been documented in the `docs/` directory
* [ ] Unit tests have been added for new jobs
* [X] Code follows the existing style and convention
* [X] API keys or sensitive information have been removed

## Additional Context
N/A